### PR TITLE
arthur-e

### DIFF
--- a/wicket-gmap3.src.js
+++ b/wicket-gmap3.src.js
@@ -122,7 +122,9 @@ Wkt.Wkt.prototype.construct = {
             } // eo for each vertex
 
             if (j !== 0) { // Reverse the order of coordinates in inner rings
-                verts.reverse();
+            	if (config.reverseInnerPolygons == null || config.reverseInnerPolygons) {
+                	  verts.reverse();
+              	}
             }
 
             rings.push(verts);


### PR DESCRIPTION
Within the datasets supplied by a third-party, the order of vertices of inner rings of a polygon is already reversed, meaning that the holes in our donuts weren't being removed.

To suppress reversion, add "reverseInnerPolygons:false" to the defaults.
