### PR TITLE
Apply path configuration to the Leaflet geometry layer constuctors

### DIFF
--- a/wicket-leaflet.src.js
+++ b/wicket-leaflet.src.js
@@ -26,27 +26,27 @@ Wkt.Wkt.prototype.construct = {
         var coords = component || this.components,
             latlngs = this.coordsToLatLngs(coords);
 
-        return L.polyline(latlngs);
+        return L.polyline(latlngs, config);
     },
 
     multilinestring: function (config) {
         var coords = this.components,
             latlngs = this.coordsToLatLngs(coords, 1);
 
-        return L.multiPolyline(latlngs);
+        return L.multiPolyline(latlngs, config);
     },
 
     polygon: function (config) {
         var coords = this.components,
             latlngs = this.coordsToLatLngs(coords, 1);
-        return L.polygon(latlngs);
+        return L.polygon(latlngs, config);
     },
 
     multipolygon: function (config) {
         var coords = this.components,
             latlngs = this.coordsToLatLngs(coords, 2);
 
-        return L.multiPolygon(latlngs);
+        return L.multiPolygon(latlngs, config);
     }
 };
 


### PR DESCRIPTION
The config options were omitted from the geometry layer constructors. Note that I only updated the src version since there was not build code available to minify it.
