### PR TITLE
can read GeoJson features (geometry + properties)

### DIFF
--- a/wicket.js
+++ b/wicket.js
@@ -236,7 +236,9 @@ this.Wkt.Wkt.prototype.fromObject = function (obj) {
  * @method
  */
 this.Wkt.Wkt.prototype.toObject = function (config) {
-    return this.construct[this.type].call(this, config);
+    var theobject = this.construct[this.type].call(this, config);
+	theobject.properties = this.properties;
+	return theobject;
 };
 
 /**
@@ -260,6 +262,12 @@ this.Wkt.Wkt.prototype.fromJson = function (obj) {
 
 	this.type = obj.type.toLowerCase();
 	this.components = [];
+	
+	if (obj.hasOwnProperty('geometry')) { //Feature
+		this.fromJson(obj.geometry);
+		this.properties = obj.properties;
+		return this;
+	}
 
 	coords = obj.coordinates;
 


### PR DESCRIPTION
This feature adds the capability to parse GeoJSON features. According to [the GeoJSON spec](http://geojson.org/), Features are _Geometries with additional properties_, so the following should be a valid GeoJSON object:

``` js
{
  "type": "Feature",
  "geometry": {
    "type": "Point",
    "coordinates": [125.6, 10.1]
  },
  "properties": {
    "name": "Dinagat Islands"
  }
}
```

In turn, Wicket will parse this as a point (or whatever geometry type it results by drilling on the object 'geometry' key), then call the framework constructor and finally add a _properties_ key.

``` js
{
    "gm_accessors_":{
        "position":null,
        "clickable":null,
        "visible":null
    },
    "position":{
        "d":10.1,
        "e":125.6
    },
    "gm_bindings_":{
        "position":{},
        "clickable":{},
        "visible":{}
    },
    "clickable":true,
    "visible":true,
    "properties":{
        "name":"Dinagat Islands"
    }
}
```

This is perfectly safe for Google Maps objects. To my knowledge, there isn't a reserved _properties_ key in Leaflet and Argcis objects either.
