### PR TITLE
chainable constructor

### DIFF
--- a/wicket.js
+++ b/wicket.js
@@ -452,6 +452,8 @@ Wkt.Wkt.prototype.toJson = function () {
  * creating a collection (MULTI-geometry) based on their types, which must agree.
  * For example, creates a MULTIPOLYGON from a POLYGON type merged with another
  * POLYGON type, or adds a POLYGON instance to a MULTIPOLYGON instance.
+ * @param   wkt {String}    A Wkt.Wkt object
+ * @return	{this.Wkt.Wkt}	The object itself
  * @memberof this.Wkt.Wkt
  * @method
  */
@@ -492,7 +494,7 @@ Wkt.Wkt.prototype.merge = function (wkt) {
 /**
  * Reads a WKT string, validating and incorporating it.
  * @param   str {String}    A WKT or GeoJSON string
- * @return      {Array}     An Array of internal geometry objects
+ * @return	{this.Wkt.Wkt}	The object itself
  * @memberof this.Wkt.Wkt
  * @method
  */


### PR DESCRIPTION
This feature changes the constructor, as well as the `read` and `merge` methods to return `this`, the Wkt.Wkt object itself.

This was mentioned in [this issue](https://github.com/arthur-e/Wicket/issues/41), and its spirit is to have constructor, `read` and `merge` to have the same behavior that `fromJson()` and `fromObject` methods. It would also allow to chain methods i.e.

``` js
new Wkt.Wkt().read("POLYGON ((30 10, 10 20, 20 40, 40 40, 30 10))").merge(new Wkt.Wkt('POLYGON((35 15,15 25,25 45,45 45,35 15))')).write();
```

returns 

``` js
"MULTIPOLYGON(((30 10,10 20,20 40,40 40,30 10)),((35 15,15 25,25 45,45 45,35 15)))"
```
