### PR TITLE
Fixed spherical error for single point/marker gmaps

### DIFF
--- a/wicket-gmap3.js
+++ b/wicket-gmap3.js
@@ -237,7 +237,9 @@
         var features, i, j, multiFlag, verts, rings, sign, tmp, response, lat, lng;
 
         // Shortcut to signed area function (determines clockwise vs counter-clock)
-        sign = google.maps.geometry.spherical.computeSignedArea;
+        if (google.maps.geometry) {
+          sign = google.maps.geometry.spherical.computeSignedArea;
+        };
 
         // google.maps.LatLng //////////////////////////////////////////////////////
         if (obj.constructor === google.maps.LatLng) {


### PR DESCRIPTION
I noticed that when you only have a single point/marker object that you want to deconstruct into a WKT object, you get an error "Uncaught TypeError: Cannot read property 'spherical' of undefined ".  Single points do not have a google.maps.geometry and this checks if that exists before continuing.
