### PR TITLE
Solution for Issue #55

### DIFF
--- a/wicket.js
+++ b/wicket.js
@@ -802,8 +802,8 @@
 						
 						//now push
 						subcomponents.push({
-							x: x_cord,
-							y: y_cord
+							x: parseFloat(x_cord),
+							y: parseFloat(y_cord)
 						});
 					}
 				}


### PR DESCRIPTION
This is one possible workaround for Issue #55 that I have opened on your repo. 

In cases where we are splitting by spaces, we need to make sure that we actually get the two coordinates(i.e. Numbers ), and not just the first two elements after splitting the coordinates by the RegEx
