### PR TITLE
enables compatibility with jasmine 2.2.1

### DIFF
--- a/tests/wicket-gmap3.html
+++ b/tests/wicket-gmap3.html
@@ -4,13 +4,13 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <title>Jasmine Spec Runner v2.0.0</title>
 
-    <link rel="shortcut icon" type="image/png" href="../node_modules/jasmine-core/dist/lib/jasmine-2.0.0/jasmine_favicon.png">
-    <link rel="stylesheet" type="text/css" href="../node_modules/jasmine-core/dist/lib/jasmine-2.0.0/jasmine.css">
+    <link rel="shortcut icon" type="image/png" href="../node_modules/jasmine-core/images/jasmine_favicon.png">
+    <link rel="stylesheet" type="text/css" href="../node_modules/jasmine-core/lib/jasmine-core/jasmine.css">
 
     <!-- Get Jasmine: https://github.com/pivotal/jasmine -->
-    <script type="text/javascript" src="../node_modules/jasmine-core/dist/lib/jasmine-2.0.0/jasmine.js"></script>
-    <script type="text/javascript" src="../node_modules/jasmine-core/dist/lib/jasmine-2.0.0/jasmine-html.js"></script>
-    <script type="text/javascript" src="../node_modules/jasmine-core/dist/lib/jasmine-2.0.0/boot.js"></script>
+    <script type="text/javascript" src="../node_modules/jasmine-core/lib/jasmine-core/jasmine.js"></script>
+    <script type="text/javascript" src="../node_modules/jasmine-core/lib/jasmine-core/jasmine-html.js"></script>
+    <script type="text/javascript" src="../node_modules/jasmine-core/lib/jasmine-core/boot.js"></script>
 
     <script src="http://maps.googleapis.com/maps/api/js?libraries=geometry&sensor=false" type="text/javascript"></script>
 


### PR DESCRIPTION
I tried to run the tests on a fresh clone of the repo, and I noticed that version 2.2.1 of Jasmine has a slightly different folder structure.

I adapted the gmaps3 test to suit the new structure.