### PR TITLE
Updated validation logic in read method to catch invalid WKT types

### DIFF
--- a/wicket.js
+++ b/wicket.js
@@ -499,12 +499,12 @@
 	Wkt.Wkt.prototype.read = function (str) {
 		var matches;
 		matches = this.regExes.typeStr.exec(str);
-		if (matches) {
+
+		//If we found a valid WKT type
+		if (this.ingest[matches[1].toLowerCase()]) {
 			this.type = matches[1].toLowerCase();
 			this.base = matches[2];
-			if (this.ingest[this.type]) {
-				this.components = this.ingest[this.type].apply(this, [this.base]);
-			}
+			this.components = this.ingest[this.type].apply(this, [this.base]);
 	
 		} else {
 			if (this.regExes.crudeJson.test(str)) {


### PR DESCRIPTION
Before this commit, the following code would not throw the "WKTError":

var bad = new Wkt.Wkt()
bad.read('Pilygin(30 40)');

After this commit, the above code will throw the error but a valid WKT will still pass