### PR TITLE
More precise definition of 'numeric'.

### DIFF
--- a/wicket.js
+++ b/wicket.js
@@ -143,7 +143,7 @@
 		this.regExes = {
 			'typeStr': /^\s*(\w+)\s*\(\s*(.*)\s*\)\s*$/,
 			'spaces': /\s+|\+/, // Matches the '+' or the empty space
-			'numeric': /-*\d+(\.*\d+)?/,
+			'numeric': /[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?/,  // Includes scientific notation
 			'comma': /\s*,\s*/,
 			'parenComma': /\)\s*,\s*\(/,
 			'coord': /-*\d+\.*\d+ -*\d+\.*\d+/, // e.g. "24 -14"


### PR DESCRIPTION
Numbers in scientific notation are now processed correctly, rather than
just using the mantissa value. E.g. '-5.78e-03' is '-0.00578', not
'-5.78'.

I found that a WKT string returned from a SQL Server geography type recently contained the following point in a LINESTRING: '-5.9530773578E-06 51.268568078'. Wicket interpreted the lng value as -5.9530773578, due to the regex for 'numeric' selecting on digits only.

I'm not sure of the impact of this more complex regex on performance, however, so I'll understand if you're reluctant to merge this one.

Excellent stuff is wicket, by the way, it has really helped me out.
