### PR TITLE
Handle ArcGIS Circle geometry deconstruction

### DIFF
--- a/wicket-arcgis.js
+++ b/wicket-arcgis.js
@@ -351,7 +351,7 @@ Wkt.Wkt.prototype.deconstruct = function (obj) {
     }
 
     // esri.geometry.Polygon ///////////////////////////////////////////////////
-    if (obj.constructor === esri.geometry.Polygon) {
+    if (obj.constructor === esri.geometry.Polygon || obj.constructor === esri.geometry.Circle) {
 
         rings = [];
         for (i = 0; i < obj.rings.length; i += 1) {


### PR DESCRIPTION
The Circle object has a different constructor, but it works exactly the same as a Polygon from a WKT perspective, so might as well allow it to be used with fromObject