### PR TITLE
Fixed error when deconstructing arcgis multipolygon with multiple inner rings

### DIFF
--- a/wicket-arcgis.js
+++ b/wicket-arcgis.js
@@ -365,7 +365,7 @@ Wkt.Wkt.prototype.deconstruct = function (obj) {
             }
 
             if (i > 0) {
-                if (Wkt.isInnerRingOf(verts, rings[i - 1], obj.spatialReference)) {
+                if (Wkt.isInnerRingOf(verts, rings[rings.length - 1], obj.spatialReference)) {
                     rings[rings.length - 1].push(verts);
                 } else {
                     rings.push([verts]);


### PR DESCRIPTION
Previously the loop would crash when `isInnerRingOf` was called, because there would be no ring at index `i - 1`. It seems like this was a mistake, and the intended index to use is `rings.length - 1`, for the previous top-level ring, which will always be a valid ring to compare with `isInnerRingOf`.