### PR TITLE
Return coordinates in the same unit as spatial reference specifies.

### DIFF
--- a/wicket-arcgis.js
+++ b/wicket-arcgis.js
@@ -296,8 +296,8 @@ Wkt.Wkt.prototype.deconstruct = function (obj) {
         return {
             type: 'point',
             components: [{
-                x: obj.getLongitude(),
-                y: obj.getLatitude()
+                x: obj.x,
+                y: obj.y
             }]
         };
 


### PR DESCRIPTION
Point features were being converted to lat/long instead of simply remaining in the coordinate system that the map is in.