### PR TITLE
fixes gmaps tests

### DIFF
--- a/tests/wicket-gmap3-spec.js
+++ b/tests/wicket-gmap3-spec.js
@@ -1,4 +1,4 @@
-describe('Standard WKT Test Cases: ', function () {
+describe('Standard WKT Test Cases: ', function() {
     var cases, wkt;
 
     wkt = new Wkt.Wkt();
@@ -582,13 +582,13 @@ describe('Standard WKT Test Cases: ', function () {
 
 
 
-    describe('Converting objects into WKT strings: ', function () {
+    describe('Converting objects into WKT strings: ', function() {
 
-        afterEach(function () {
+        afterEach(function() {
             wkt.delimiter = ' ';
         });
 
-        it('should convert a Marker instance into a basic POINT string', function () {
+        it('should convert a Marker instance into a basic POINT string', function() {
             wkt.fromObject(cases.point.obj);
             expect(wkt.type).toBe('point');
             expect(wkt.isCollection()).toBe(false);
@@ -596,7 +596,7 @@ describe('Standard WKT Test Cases: ', function () {
             expect(wkt.write()).toBe(cases.point.str);
         });
 
-        it('should convert a Polyline instance into a basic LINESTRING string', function () {
+        it('should convert a Polyline instance into a basic LINESTRING string', function() {
             wkt.fromObject(cases.linestring.obj);
             expect(wkt.type).toBe('linestring');
             expect(wkt.isCollection()).toBe(false);
@@ -604,7 +604,7 @@ describe('Standard WKT Test Cases: ', function () {
             expect(wkt.write()).toBe(cases.linestring.str);
         });
 
-        it('should convert a Polygon instance into a basic POLYGON string', function () {
+        it('should convert a Polygon instance into a basic POLYGON string', function() {
             wkt.fromObject(cases.polygon.obj);
             expect(wkt.type).toBe('polygon');
             expect(wkt.isCollection()).toBe(true);
@@ -612,7 +612,7 @@ describe('Standard WKT Test Cases: ', function () {
             expect(wkt.write()).toBe(cases.polygon.str);
         });
 
-        it('should convert a Polygon instance with a hole into a POLYGON string with the same hole', function () {
+        it('should convert a Polygon instance with a hole into a POLYGON string with the same hole', function() {
             wkt.fromObject(cases.polygon2.obj);
             expect(wkt.type).toBe('polygon');
             expect(wkt.isCollection()).toBe(true);
@@ -620,7 +620,7 @@ describe('Standard WKT Test Cases: ', function () {
             expect(wkt.write()).toBe(cases.polygon2.str);
         });
 
-        it('should convert a Rectangle instance into a POLYGON string', function () {
+        it('should convert a Rectangle instance into a POLYGON string', function() {
             wkt.fromObject(cases.rectangle.obj);
             expect(wkt.type).toBe('polygon');
             expect(wkt.isRectangle).toBe(true);
@@ -629,7 +629,7 @@ describe('Standard WKT Test Cases: ', function () {
             expect(wkt.write()).toBe(cases.rectangle.str);
         });
 
-        it('should convert an Array of Marker instances into a MULTIPOINT string', function () {
+        it('should convert an Array of Marker instances into a MULTIPOINT string', function() {
             wkt.fromObject(cases.multipoint.obj);
             expect(wkt.type).toBe('multipoint');
             expect(wkt.isCollection()).toBe(true);
@@ -637,7 +637,7 @@ describe('Standard WKT Test Cases: ', function () {
             expect(wkt.write()).toBe(cases.multipoint.str);
         });
 
-        it('should convert an Array of Polyline instances into a MULTILINESTRING string', function () {
+        it('should convert an Array of Polyline instances into a MULTILINESTRING string', function() {
             wkt.fromObject(cases.multilinestring.obj);
             expect(wkt.type).toBe('multilinestring');
             expect(wkt.isCollection()).toBe(true);
@@ -645,7 +645,7 @@ describe('Standard WKT Test Cases: ', function () {
             expect(wkt.write()).toBe(cases.multilinestring.str);
         });
 
-        it('should convert an Array of Polygon instances into a MULTIPOLYGON string', function () {
+        it('should convert an Array of Polygon instances into a MULTIPOLYGON string', function() {
             wkt.fromObject(cases.multipolygon.obj);
             expect(wkt.type).toBe('multipolygon');
             expect(wkt.isCollection()).toBe(true);
@@ -653,7 +653,7 @@ describe('Standard WKT Test Cases: ', function () {
             expect(wkt.write()).toBe(cases.multipolygon.str);
         });
 
-        it('should convert an Array of Polygon instances, some with holes, into a MULTIPOLYGON string with the same hole', function () {
+        it('should convert an Array of Polygon instances, some with holes, into a MULTIPOLYGON string with the same hole', function() {
             wkt.fromObject(cases.multipolygon2.obj);
             expect(wkt.type).toBe('multipolygon');
             expect(wkt.isCollection()).toBe(true);
@@ -781,45 +781,53 @@ describe('Standard WKT Test Cases: ', function () {
     });
 
 
-    describe('Coverting WKT strings into objects: ', function () {
+    describe('Coverting WKT strings into objects: ', function() {
 
-        afterEach(function () {
+        afterEach(function() {
             wkt.delimiter = ' ';
         });
 
-        it('should convert a basic POINT string to a Marker instance', function () {
+        it('should convert a basic POINT string to a Marker instance', function() {
             wkt.read(cases.marker.str);
             expect(wkt.type).toBe('point');
             expect(wkt.isCollection()).toBe(false);
             expect(wkt.components).toEqual(cases.marker.cmp);
-            expect(wkt.toObject().getPosition()).toEqual(cases.marker.obj.getPosition());
+            expect(wkt.toObject().getPosition().toString()).toEqual(cases.marker.obj.getPosition().toString());
         });
 
-        it('should convert a basic LINESTRING string to a Polyline instance', function () {
+        it('should convert a basic LINESTRING string to a Polyline instance', function() {
             wkt.read(cases.linestring.str);
             expect(wkt.type).toBe('linestring');
             expect(wkt.isCollection()).toBe(false);
             expect(wkt.components).toEqual(cases.linestring.cmp);
-            expect(wkt.toObject().getPath()).toEqual(cases.linestring.obj.getPath());
+            expect(wkt.toObject().getPath().getArray().toString()).toEqual(cases.linestring.obj.getPath().getArray().toString());
         });
 
-        it('should convert a basic POLYGON string to a Polygon instance', function () {
+        it('should convert a basic POLYGON string to a Polygon instance', function() {
             wkt.read(cases.polygon.str);
             expect(wkt.type).toBe('polygon');
             expect(wkt.isCollection()).toBe(true);
             expect(wkt.components).toEqual(cases.polygon.cmp);
-            expect(wkt.toObject().getPaths()).toEqual(cases.polygon.obj.getPaths());
+            expect(wkt.toObject().getPaths().getArray().map(function(ring) {
+                return ring.getArray();
+            }).toString()).toEqual(cases.polygon.obj.getPaths().getArray().map(function(ring) {
+                return ring.getArray();
+            }).toString());
         });
 
-        it('should convert a POLYGON string with a hole to a Polygon instance with the same hole', function () {
+        it('should convert a POLYGON string with a hole to a Polygon instance with the same hole', function() {
             wkt.read(cases.polygon2.str);
             expect(wkt.type).toBe('polygon');
             expect(wkt.isCollection()).toBe(true);
             expect(wkt.components).toEqual(cases.polygon2.cmp);
-            expect(wkt.toObject().getPaths()).toEqual(cases.polygon2.obj.getPaths());
+            expect(wkt.toObject().getPaths().getArray().map(function(ring) {
+                return ring.getArray();
+            }).toString()).toEqual(cases.polygon2.obj.getPaths().getArray().map(function(ring) {
+                return ring.getArray();
+            }).toString());
         });
 
-        it('should convert a POLYGON string, with isRectangle=true, into a Rectangle instance', function () {
+        it('should convert a POLYGON string, with isRectangle=true, into a Rectangle instance', function() {
             wkt.read(cases.rectangle.str);
             wkt.isRectangle = true;
             expect(wkt.type).toBe('polygon');
@@ -829,7 +837,7 @@ describe('Standard WKT Test Cases: ', function () {
             expect(wkt.toObject().constructor).toEqual(google.maps.Rectangle);
         });
 
-        it('should convert a MULTIPOINT string into an Array of Marker instances', function () {
+        it('should convert a MULTIPOINT string into an Array of Marker instances', function() {
             var m;
 
             wkt.read(cases.multipoint.str);
@@ -839,16 +847,25 @@ describe('Standard WKT Test Cases: ', function () {
 
             markers = wkt.toObject();
             for (m = 0; m < markers.length; m += 1) {
-                expect(markers[m].getPosition()).toEqual(cases.multipoint.obj[m].getPosition());
+                expect(markers[m].getPosition().toString()).toEqual(cases.multipoint.obj[m].getPosition().toString());
             }
         });
 
-        it('should convert a MULTILINESTRING string into an Array of Polyline instances', function () {
+        it('should convert a MULTILINESTRING string into an Array of Polyline instances', function() {
             wkt.read(cases.multilinestring.str);
             expect(wkt.type).toBe('multilinestring');
             expect(wkt.isCollection()).toBe(true);
             expect(wkt.components).toEqual(cases.multilinestring.cmp);
-            expect(wkt.toObject()).toEqual(cases.multilinestring.obj);
+            //console.debug({wkt:wkt.toObject(), cases:cases.multilinestring.obj});
+            expect(wkt.toObject().map(function(linestring) {
+                return linestring.getPath().getArray().map(function(point) {
+                    return point.toString();
+                });
+            })).toEqual(cases.multilinestring.obj.map(function(linestring) {
+                return linestring.getPath().getArray().map(function(point) {
+                    return point.toString();
+                });
+            }));
         });
 
         it('should convert a MULTIPOLYGON string into an Array of Polygon instances', function () {
@@ -856,7 +873,17 @@ describe('Standard WKT Test Cases: ', function () {
             expect(wkt.type).toBe('multipolygon');
             expect(wkt.isCollection()).toBe(true);
             expect(wkt.components).toEqual(cases.multipolygon.cmp);
-            expect(wkt.toObject()).toEqual(cases.multipolygon.obj);
+
+            expect(wkt.toObject().map(function(ring) {
+                return ring.getPath().getArray().map(function(point) {
+                    return point.toString();
+                });
+            })).toEqual(cases.multipolygon.obj.map(function(ring) {
+                return ring.getPath().getArray().map(function(point) {
+                    return point.toString();
+                });
+            }));
+
         });
 
         it('should convert a MULTIPOLYGON string with holes into an Array of Polygon instances with the same holes', function () {
@@ -864,7 +891,16 @@ describe('Standard WKT Test Cases: ', function () {
             expect(wkt.type).toBe('multipolygon');
             expect(wkt.isCollection()).toBe(true);
             expect(wkt.components).toEqual(cases.multipolygon2.cmp);
-            expect(wkt.toObject()).toEqual(cases.multipolygon2.obj);
+            
+             expect(wkt.toObject().map(function(ring) {
+                return ring.getPath().getArray().map(function(point) {
+                    return point.toString();
+                });
+            })).toEqual(cases.multipolygon2.obj.map(function(ring) {
+                return ring.getPath().getArray().map(function(point) {
+                    return point.toString();
+                });
+            }));
         });
 
         it('should convert a PostGIS 2DBOX string into a Rectangle instance', function () {

--- a/tests/wicket-gmap3.html
+++ b/tests/wicket-gmap3.html
@@ -12,7 +12,7 @@
     <script type="text/javascript" src="../node_modules/jasmine-core/lib/jasmine-core/jasmine-html.js"></script>
     <script type="text/javascript" src="../node_modules/jasmine-core/lib/jasmine-core/boot.js"></script>
 
-    <script src="http://maps.googleapis.com/maps/api/js?libraries=geometry&sensor=false" type="text/javascript"></script>
+    <script src="http://maps.googleapis.com/maps/api/js?libraries=geometry" type="text/javascript"></script>
 
     <!-- include source files here... -->
     <script type="text/javascript" src="../wicket.js"></script>


### PR DESCRIPTION
The `sensor` parameter is deprecated and throws a warning when including the google maps library. This PR removes it.

Also, at some point in the recent releases, when google maps api instances an object it is assigned an internal id, which means another instance with the same coordinates or path won't satisfy Jasmine's `.toEqual` method.

In this PR, the tests are modified to cast LatLng objects as string, and map rings and linestrings as array of stringified LatLng objects. This way only the position is compared whereas the inner id is simply ignored.