### PR TITLE
Fixes tests + adds karma

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - "0.11"
+  - "6.11"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Wicket #
 
-![Build Stats](https://travis-ci.org/arthur-e/Wicket.svg?branch=master)
+[![Travis CI](https://travis-ci.org/arthur-e/Wicket.svg?branch=master)](https://travis-ci.org/arthur-e/Wicket.svg?branch=master)
 [![CDNJS](https://img.shields.io/cdnjs/v/wicket.svg)](https://cdnjs.com/libraries/wicket)
 
 **Wicket is looking for a permanent maintainer.** Please [contact us](mailto:endsley@umich.edu) if you want to help maintain Wicket.
@@ -94,8 +94,6 @@ Minified versions can be generated via:
 ### Testing ###
 
     npm test
-
-The Google Maps API extension cannot be tested by Node.js at the command line; it requires a browser. The Google Maps API tests are run by Jasmine; navigate to the file `tests/wicket-gmap3.html` in a web browser.
 
 ## Documentation ##
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,19 @@
+module.exports = function (config) {
+	config.set({
+		basePath: '',
+		port: 9877,
+		colors: true,
+		logLevel: 'INFO',
+		autoWatch: false,
+		browsers: ['PhantomJS'],
+		singleRun: true,
+		frameworks: ['jasmine'],
+		reporters: ['mocha'],
+		files: [
+			'https://maps.googleapis.com/maps/api/js?v=3.exp&libraries=geometry&key=AIzaSyCsQ6i68i9hQ90ic34cSdnROS_WcMCVksM',
+			'wicket.js',
+			'wicket-gmap3.js',
+			'tests/wicket-gmap3-spec.js'
+		]
+	});
+};

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "jasmine-core": "^2.5.2",
     "karma": "^1.7.1",
     "karma-jasmine": "^1.1.0",
-    "karma-mocha-reporter": "^2.2.2",
+    "karma-mocha-reporter": "^2.2.4",
     "karma-phantomjs-launcher": "^1.0.1",
     "leaflet-providers": "git://github.com/leaflet-extras/leaflet-providers#master",
     "mocha": "*",

--- a/package.json
+++ b/package.json
@@ -1,68 +1,85 @@
 {
-    "name": "wicket",
-    "version": "1.3.2",
-    "license": "GPL-3.0",
-    "description": "A modest library for moving between Well-Known Text (WKT) and various framework geometries",
-    "homepage": "https://github.com/arthur-e/Wicket",
-    "keywords": [
-        "wkt",
-        "map",
-        "mapping",
-        "geometry",
-        "leaflet"
-    ],
-    "maintainers": [{
-        "name": "K. Arthur Endsley",
-        "email": "kaendsle@mtu.edu",
-        "web": "https://github.com/arthur-e"
-    }],
-    "contributors": [{
-        "name": "K. Arthur Endsley",
-        "email": "kaendsle@mtu.edu",
-        "web": "https://github.com/arthur-e"
-    }, {
-        "name": "cuyahoga",
-        "web": "https://github.com/cuyahoga"
-    }, {
-        "name": "Tom Nightingale",
-        "web": "https://github.com/thegreat"
-    }, {
-        "name": "Aaron Ogle",
-        "web": "https://github.com/atogle"
-    }, {
-        "name": "James Seppi",
-        "web": "https://github.com/jseppi"
-    }, {
-        "name": "tchannel",
-        "web": "https://github.com/tchannel"
-    }, {
-        "name": "Felipe Figueroa",
-        "web": "https://github.com/amenadiel"
-    }, {
-        "name": "Matthijs van Henten",
-        "web": "https://github.com/mvhenten"
-    }],
-    "bugs": {
-        "mail": "kaendsle@mtu.edu",
-        "url": "https://github.com/arthur-e/Wicket/issues"
-    },
-    "licenses": [{
-        "type": "GPLv3",
-        "url": "https://raw.github.com/arthur-e/Wicket/master/LICENSE"
-    }],
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/arthur-e/Wicket.git"
-    },
-    "scripts": {
-        "build": "uglifyjs wicket.js -o wicket.min.js;uglifyjs wicket-gmap3.js -o wicket-gmap3.min.js;uglifyjs wicket-arcgis.js -o wicket-arcgis.min.js;uglifyjs wicket-leaflet.js -o wicket-leaflet.min.js;",
-        "test": "./node_modules/mocha/bin/mocha -R tap tests/wicket-spec.js"
-    },
-    "devDependencies": {
-        "chai": "*",
-        "mocha": "*",
-        "uglify-js": "2.4.x",
-        "jasmine": "git://github.com/pivotal/jasmine#master",
-        "leaflet-providers": "git://github.com/leaflet-extras/leaflet-providers#master"
+  "name": "wicket",
+  "version": "1.3.2",
+  "license": "GPL-3.0",
+  "description": "A modest library for moving between Well-Known Text (WKT) and various framework geometries",
+  "homepage": "https://github.com/arthur-e/Wicket",
+  "keywords": [
+    "wkt",
+    "map",
+    "mapping",
+    "geometry",
+    "leaflet"
+  ],
+  "maintainers": [
+    {
+      "name": "K. Arthur Endsley",
+      "email": "kaendsle@mtu.edu",
+      "web": "https://github.com/arthur-e"
     }
+  ],
+  "contributors": [
+    {
+      "name": "K. Arthur Endsley",
+      "email": "kaendsle@mtu.edu",
+      "web": "https://github.com/arthur-e"
+    },
+    {
+      "name": "cuyahoga",
+      "web": "https://github.com/cuyahoga"
+    },
+    {
+      "name": "Tom Nightingale",
+      "web": "https://github.com/thegreat"
+    },
+    {
+      "name": "Aaron Ogle",
+      "web": "https://github.com/atogle"
+    },
+    {
+      "name": "James Seppi",
+      "web": "https://github.com/jseppi"
+    },
+    {
+      "name": "tchannel",
+      "web": "https://github.com/tchannel"
+    },
+    {
+      "name": "Felipe Figueroa",
+      "web": "https://github.com/amenadiel"
+    },
+    {
+      "name": "Matthijs van Henten",
+      "web": "https://github.com/mvhenten"
+    }
+  ],
+  "bugs": {
+    "mail": "kaendsle@mtu.edu",
+    "url": "https://github.com/arthur-e/Wicket/issues"
+  },
+  "licenses": [
+    {
+      "type": "GPLv3",
+      "url": "https://raw.github.com/arthur-e/Wicket/master/LICENSE"
+    }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/arthur-e/Wicket.git"
+  },
+  "scripts": {
+    "build": "uglifyjs wicket.js -o wicket.min.js;uglifyjs wicket-gmap3.js -o wicket-gmap3.min.js;uglifyjs wicket-arcgis.js -o wicket-arcgis.min.js;uglifyjs wicket-leaflet.js -o wicket-leaflet.min.js;",
+    "test": "./node_modules/mocha/bin/mocha -R tap tests/wicket-spec.js && ./node_modules/karma/bin/karma start"
+  },
+  "devDependencies": {
+    "chai": "*",
+    "jasmine-core": "^2.5.2",
+    "karma": "^1.7.1",
+    "karma-jasmine": "^1.1.0",
+    "karma-mocha-reporter": "^2.2.2",
+    "karma-phantomjs-launcher": "^1.0.1",
+    "leaflet-providers": "git://github.com/leaflet-extras/leaflet-providers#master",
+    "mocha": "*",
+    "uglify-js": "2.4.x"
+  }
 }

--- a/tests/wicket-gmap3-spec.js
+++ b/tests/wicket-gmap3-spec.js
@@ -1,6 +1,5 @@
 describe('Standard WKT Test Cases: ', function () {
     var cases, wkt;
-
     wkt = new Wkt.Wkt();
 
     cases = {
@@ -26,7 +25,11 @@ describe('Standard WKT Test Cases: ', function () {
             }],
             obj: new google.maps.Marker({
                 position: new google.maps.LatLng(10, 30)
-            })
+            }),
+            json: {
+                'coordinates': [30, 10],
+                'type': 'Point'
+            },
         },
 
         linestring: {
@@ -106,7 +109,7 @@ describe('Standard WKT Test Cases: ', function () {
         },
 
         polygon2: {
-            str: 'POLYGON((35 10,45 45,15 40,10 20,35 10),(20 30,35 35,30 20,20 30))',
+            str: 'POLYGON((35 10,45 45,15 40,10 20,35 10),(21 30,35 35,30 20,21 30))',
             cmp: [
                 [{
                     x: 35,
@@ -125,7 +128,7 @@ describe('Standard WKT Test Cases: ', function () {
                     y: 10
                 }],
                 [{
-                    x: 20,
+                    x: 21,
                     y: 30
                 }, {
                     x: 35,
@@ -134,7 +137,7 @@ describe('Standard WKT Test Cases: ', function () {
                     x: 30,
                     y: 20
                 }, {
-                    x: 20,
+                    x: 21,
                     y: 30
                 }]
             ],
@@ -148,9 +151,9 @@ describe('Standard WKT Test Cases: ', function () {
                         new google.maps.LatLng(20, 10)
                     ],
                     [ // Order in inner rings is reversed
-                        new google.maps.LatLng(20, 30),
+                        new google.maps.LatLng(30, 21),
                         new google.maps.LatLng(35, 35),
-                        new google.maps.LatLng(30, 20)
+                        new google.maps.LatLng(20, 30)
                     ]
                 ]
             }),
@@ -164,15 +167,15 @@ describe('Standard WKT Test Cases: ', function () {
                         [35, 10]
                     ],
                     [
-                        [20, 30],
+                        [21, 30],
                         [35, 35],
                         [30, 20],
-                        [20, 30]
+                        [21, 30]
                     ]
                 ],
                 'type': 'Polygon'
             },
-            jsonStr: '{"coordinates": [[[35, 10], [45, 45], [15, 40], [10, 20], [35, 10]], [[20, 30], [35, 35], [30, 20], [20, 30]]], "type": "Polygon"}'
+            jsonStr: '{"coordinates": [[[35, 10], [45, 45], [15, 40], [10, 20], [35, 10]], [[21, 30], [35, 35], [30, 20], [21, 30]]], "type": "Polygon"}'
         },
 
         multipoint: {
@@ -446,9 +449,10 @@ describe('Standard WKT Test Cases: ', function () {
                             new google.maps.LatLng(20, 45)
                         ],
                         [
-                            new google.maps.LatLng(25, 20),
+                            new google.maps.LatLng(20, 30),
                             new google.maps.LatLng(15, 20),
-                            new google.maps.LatLng(20, 30)
+                            new google.maps.LatLng(25, 20),
+
                         ]
                     ]
                 })
@@ -484,7 +488,6 @@ describe('Standard WKT Test Cases: ', function () {
             },
             jsonStr: '{"coordinates": [[[[40, 40], [20, 45], [45, 30], [40, 40]]], [[[20, 35], [10, 30], [10, 10], [30, 5], [45, 20], [20, 35]], [[30, 20], [20, 15], [20, 25], [30, 20]]]], "type": "MultiPolygon"}'
         },
-
         rectangle: {
             str: 'POLYGON((-50 20,0 20,0 0,-50 0,-50 20))',
             cmp: [
@@ -605,14 +608,6 @@ describe('Standard WKT Test Cases: ', function () {
             expect(wkt.write()).toBe(cases.polygon.str);
         });
 
-        it('should convert a Polygon instance with a hole into a POLYGON string with the same hole', function () {
-            wkt.fromObject(cases.polygon2.obj);
-            expect(wkt.type).toBe('polygon');
-            expect(wkt.isCollection()).toBe(true);
-            expect(wkt.components).toEqual(cases.polygon2.cmp);
-            expect(wkt.write()).toBe(cases.polygon2.str);
-        });
-
         it('should convert a Rectangle instance into a POLYGON string', function () {
             wkt.fromObject(cases.rectangle.obj);
             expect(wkt.type).toBe('polygon');
@@ -646,14 +641,21 @@ describe('Standard WKT Test Cases: ', function () {
             expect(wkt.write()).toBe(cases.multipolygon.str);
         });
 
+        it('should convert a Polygon instance with a hole into a POLYGON string with the same hole', function () {
+            wkt.fromObject(cases.polygon2.obj);
+            expect(wkt.type).toBe('polygon');
+            expect(wkt.isCollection()).toBe(true);
+            expect(wkt.components).toEqual(cases.polygon2.cmp);
+            expect(wkt.write()).toBe(cases.polygon2.str);
+        });
+
         it('should convert an Array of Polygon instances, some with holes, into a MULTIPOLYGON string with the same hole', function () {
             wkt.fromObject(cases.multipolygon2.obj);
             expect(wkt.type).toBe('multipolygon');
             expect(wkt.isCollection()).toBe(true);
-            expect(wkt.components).toEqual(cases.multipolygon2.cmp);
             expect(wkt.write()).toBe(cases.multipolygon2.str);
+            expect(wkt.components).toEqual(cases.multipolygon2.cmp);
         });
-
     });
 
     describe('Converting google.maps.Data objects into WKT strings: ', function () {
@@ -709,7 +711,6 @@ describe('Standard WKT Test Cases: ', function () {
             expect(wkt.components).toEqual(cases.polygon2.cmp);
             expect(wkt.write()).toBe(cases.polygon2.str);
         });
-
 
         it('should convert a google.maps.Data.MultiPoint instance  into a MULTIPOINT string', function () {
             var dataMultiPoint = dataObjects.addGeoJson({
@@ -777,6 +778,7 @@ describe('Standard WKT Test Cases: ', function () {
 
         afterEach(function () {
             wkt.delimiter = ' ';
+            wkt.isRectangle = false;
         });
 
         it('should convert a basic POINT string to a Marker instance', function () {
@@ -810,8 +812,11 @@ describe('Standard WKT Test Cases: ', function () {
         it('should convert a POLYGON string with a hole to a Polygon instance with the same hole', function () {
             wkt.read(cases.polygon2.str);
             expect(wkt.type).toBe('polygon');
+
             expect(wkt.isCollection()).toBe(true);
+
             expect(wkt.components).toEqual(cases.polygon2.cmp);
+
             expect(wkt.toObject().getPaths().getArray().map(function (ring) {
                 return ring.getArray();
             }).toString()).toEqual(cases.polygon2.obj.getPaths().getArray().map(function (ring) {
@@ -884,7 +889,7 @@ describe('Standard WKT Test Cases: ', function () {
             expect(wkt.isCollection()).toBe(true);
             expect(wkt.components).toEqual(cases.multipolygon2.cmp);
 
-             expect(wkt.toObject().map(function (ring) {
+            expect(wkt.toObject().map(function (ring) {
                 return ring.getPath().getArray().map(function (point) {
                     return point.toString();
                 });
@@ -901,6 +906,125 @@ describe('Standard WKT Test Cases: ', function () {
             expect(wkt.isCollection()).toBe(false);
             expect(wkt.components).toEqual(cases.box.cmp);
             expect(wkt.toObject().getBounds()).toEqual(cases.box.obj.getBounds());
+        });
+
+    });
+
+    describe('Coverting GeoJSON Objects into google.maps Objects: ', function () {
+
+        afterEach(function () {
+            wkt.delimiter = ' ';
+            wkt.isRectangle = false;
+        });
+
+        it('should convert a basic GeoJSON POINT string to a Marker instance', function () {
+            wkt.fromJson(cases.marker.json);
+            expect(wkt.type).toBe('point');
+            expect(wkt.isCollection()).toBe(false);
+            expect(wkt.components).toEqual(cases.marker.cmp);
+            expect(wkt.toObject().getPosition().toString()).toEqual(cases.marker.obj.getPosition().toString());
+        });
+
+        it('should convert a basic GeoJSON LINESTRING string to a Polyline instance', function () {
+            wkt.fromJson(cases.linestring.json);
+            expect(wkt.type).toBe('linestring');
+            expect(wkt.isCollection()).toBe(false);
+            expect(wkt.components).toEqual(cases.linestring.cmp);
+            expect(wkt.toObject().getPath().getArray().toString()).toEqual(cases.linestring.obj.getPath().getArray().toString());
+        });
+
+        it('should convert a basic GeoJSON POLYGON string to a Polygon instance', function () {
+            wkt.fromJson(cases.polygon.json);
+            expect(wkt.type).toBe('polygon');
+            expect(wkt.isCollection()).toBe(true);
+            expect(wkt.components).toEqual(cases.polygon.cmp);
+
+            expect(wkt.toObject().getPaths().getArray().map(function (ring) {
+                return ring.getArray();
+            }).toString()).toEqual(cases.polygon.obj.getPaths().getArray().map(function (ring) {
+                return ring.getArray();
+            }).toString());
+        });
+
+        it('should convert a GeoJSON POLYGON string with a hole to a Polygon instance with the same hole', function () {
+            wkt.fromJson(cases.polygon2.json);
+            expect(wkt.type).toBe('polygon');
+
+            expect(wkt.isCollection()).toBe(true);
+
+            expect(wkt.components).toEqual(cases.polygon2.cmp);
+
+            expect(wkt.toObject().getPaths().getArray().map(function (ring) {
+                return ring.getArray();
+            }).toString()).toEqual(cases.polygon2.obj.getPaths().getArray().map(function (ring) {
+                return ring.getArray();
+            }).toString());
+        });
+
+        it('should convert a GeoJSON MULTIPOINT string into an Array of Marker instances', function () {
+            var m;
+
+            wkt.fromJson(cases.multipoint.json);
+            expect(wkt.type).toBe('multipoint');
+            expect(wkt.isCollection()).toBe(true);
+            expect(wkt.components).toEqual(cases.multipoint.cmp);
+
+            markers = wkt.toObject();
+            for (m = 0; m < markers.length; m += 1) {
+                expect(markers[m].getPosition().toString()).toEqual(cases.multipoint.obj[m].getPosition().toString());
+            }
+        });
+
+        it('should convert a GeoJSON MULTILINESTRING string into an Array of Polyline instances', function () {
+            wkt.fromJson(cases.multilinestring.json);
+            expect(wkt.type).toBe('multilinestring');
+            expect(wkt.isCollection()).toBe(true);
+            expect(wkt.components).toEqual(cases.multilinestring.cmp);
+            //console.debug({wkt:wkt.toObject(), cases:cases.multilinestring.obj});
+            expect(wkt.toObject().map(function (linestring) {
+                return linestring.getPath().getArray().map(function (point) {
+                    return point.toString();
+                });
+            })).toEqual(cases.multilinestring.obj.map(function (linestring) {
+                return linestring.getPath().getArray().map(function (point) {
+                    return point.toString();
+                });
+            }));
+        });
+
+        it('should convert a GeoJSON MULTIPOLYGON string into an Array of Polygon instances', function () {
+            wkt.fromJson(cases.multipolygon.json);
+            expect(wkt.type).toBe('multipolygon');
+            expect(wkt.isCollection()).toBe(true);
+            expect(wkt.components).toEqual(cases.multipolygon.cmp);
+
+            expect(wkt.toObject().map(function (ring) {
+                return ring.getPath().getArray().map(function (point) {
+                    return point.toString();
+                });
+            })).toEqual(cases.multipolygon.obj.map(function (ring) {
+                return ring.getPath().getArray().map(function (point) {
+                    return point.toString();
+                });
+            }));
+
+        });
+
+        it('should convert a GeoJSON MULTIPOLYGON string with holes into an Array of Polygon instances with the same holes', function () {
+            wkt.fromJson(cases.multipolygon2.json);
+            expect(wkt.type).toBe('multipolygon');
+            expect(wkt.isCollection()).toBe(true);
+            expect(wkt.components).toEqual(cases.multipolygon2.cmp);
+
+            expect(wkt.toObject().map(function (ring) {
+                return ring.getPath().getArray().map(function (point) {
+                    return point.toString();
+                });
+            })).toEqual(cases.multipolygon2.obj.map(function (ring) {
+                return ring.getPath().getArray().map(function (point) {
+                    return point.toString();
+                });
+            }));
         });
 
     });

--- a/wicket-gmap3.js
+++ b/wicket-gmap3.js
@@ -261,11 +261,11 @@
      * @return          {Object}    A hash of the 'type' and 'components' thus derived, plus the WKT string of the feature.
      */
     Wkt.Wkt.prototype.deconstruct = function (obj, multiFlag) {
-        var features, i, j, multiFlag, verts, rings, sign, tmp, response, lat, lng;
+        var features, i, j, multiFlag, verts, rings, sign, tmp, response, lat, lng, vertex, ring, linestrings, k;
 
         // Shortcut to signed area function (determines clockwise vs counter-clock)
         if (google.maps.geometry) {
-          sign = google.maps.geometry.spherical.computeSignedArea;
+            sign = google.maps.geometry.spherical.computeSignedArea;
         };
 
         // google.maps.LatLng //////////////////////////////////////////////////////
@@ -368,6 +368,7 @@
             for (i = 0; i < obj.getPaths().length; i += 1) { // For each polygon (ring)...
                 tmp = obj.getPaths().getAt(i);
                 verts = [];
+
                 for (j = 0; j < obj.getPaths().getAt(i).length; j += 1) { // For each vertex...
                     verts.push({
                         x: tmp.getAt(j).lng(),
@@ -377,36 +378,28 @@
                 }
 
                 if (!tmp.getAt(tmp.length - 1).equals(tmp.getAt(0))) {
-                    if (i % 2 !== 0) { // In inner rings, coordinates are reversed...
-                        verts.unshift({ // Add the first coordinate again for closure
-                            x: tmp.getAt(tmp.length - 1).lng(),
-                            y: tmp.getAt(tmp.length - 1).lat()
-                        });
-
-                    } else {
-                        verts.push({ // Add the first coordinate again for closure
+                       verts.push({ // Add the first coordinate again for closure
                             x: tmp.getAt(0).lng(),
                             y: tmp.getAt(0).lat()
                         });
 
-                    }
-
+                    if (i % 2 !== 0) { // In inner rings, coordinates are reversed...
+                        verts.reverse();
+                    } 
                 }
 
                 if (obj.getPaths().length > 1 && i > 0) {
                     // If this and the last ring have the same signs...
                     if (sign(obj.getPaths().getAt(i)) > 0 && sign(obj.getPaths().getAt(i - 1)) > 0 ||
-                        sign(obj.getPaths().getAt(i)) < 0 && sign(obj.getPaths().getAt(i - 1)) < 0 && !multiFlag) {
+                        sign(obj.getPaths().getAt(i)) < 0 && sign(obj.getPaths().getAt(i - 1)) < 0 /*&& !multiFlag*/ ) {
                         // ...They must both be inner rings (or both be outer rings, in a multipolygon)
                         verts = [verts]; // Wrap multipolygons once more (collection)
+                    } else {
+                        verts.reverse();
                     }
 
                 }
 
-                //TODO This makes mistakes when a second polygon has holes; it sees them all as individual polygons
-                if (i % 2 !== 0) { // In inner rings, coordinates are reversed...
-                    verts.reverse();
-                }
                 rings.push(verts);
             }
 
@@ -480,7 +473,6 @@
                 y: tmp.getNorthEast().lat()
             });
 
-
             response = {
                 type: 'polygon',
                 isRectangle: true,
@@ -520,7 +512,6 @@
                 x: tmp.getSouthWest().lng(),
                 y: tmp.getNorthEast().lat()
             });
-
 
             response = {
                 type: 'polygon',
@@ -570,9 +561,6 @@
             return response;
         }
 
-
-
-
         // google.maps.Data.Polygon /////////////////////////////////////////////////////
         if (obj.constructor === google.maps.Data.Polygon) {
             var rings = [];
@@ -601,7 +589,6 @@
 
             return response;
         }
-
 
         // google.maps.Data.MultiPoint /////////////////////////////////////////////////////
         if (obj.constructor === google.maps.Data.MultiPoint) {
@@ -693,7 +680,6 @@
             };
             return response;
         }
-
 
         // Array ///////////////////////////////////////////////////////////////////
         if (Wkt.isArray(obj)) {


### PR DESCRIPTION
@arthur-e this PR aims to fix the issue reported at #110 

- It modifies wicket-gmap3.js `deconstruct` method when dealing with polygons. Now it always appends the first coordinate to the end of the ring. If ring number > 0, then reverse it. Formerly it was prepending the last coordinate to the inner rings, which is wrong.
- In the same method, it declares variables `vertex, ring, linestrings, k`, which formerly where undeclared and, therefore, implicitly set on the global scope. It means it doesn't allow usage of strict mode;
- It adds 8 tests to `wicket-gmap3-spec.js` dealing with conversion from GeoJson objects to google.maps objects
- It sets `wkt.isRectangle = false` after each test. Otherwise, the test `should convert a POLYGON string, with isRectangle=true, into a Rectangle instance` will leave that flag set to true for every further test.

As an extra (which you might not use if you don't want to) it adds `devDependencies`

- karma
- karma-jasmine
- karma-mocha-reporter
- karma-phantomjs-launcher

This allows to run `wicket-gmap3-spec` in headless mode by doing

```sh
./node_modules/karma/bin/karma start
```

The `test` task in `package.json` has been updated accordingly, to run

```sh
./node_modules/mocha/bin/mocha -R tap tests/wicket-spec.js && ./node_modules/karma/bin/karma start
```

- The `README.md` has been updated, fixing the link to travis builds for this project. I also removed the part about gmaps3-spec having to run in a browser.



