### PR TITLE
Fix ArcGIS polygon from WKT multipolygon

### DIFF
--- a/wicket-arcgis-amd.js
+++ b/wicket-arcgis-amd.js
@@ -202,41 +202,21 @@ define([
             return new Polygon({
                 // Create an Array of rings...
                 rings: (function () {
-                    var i, j, holey, newRings, rings;
-
-                    holey = false; // Assume there are no inner rings (holes)
-                    rings = that.components.map(function (i) {
-                        // ...Within which are Arrays of (outer) rings (polygons)
-                        var rings = i.map(function (j) {
-                            // ...Within which are (possibly) Arrays of (inner) rings (holes)
-                            return j.map(function (k) {
+                    var rings = [];
+                    that.components.forEach(function (polygon) {
+                        polygon.forEach(function (exteriorOrHole) {
+                            // ArcGis expects a flat array of rings
+                            // The direction of the ring determines if it is a hole or an exterior
+                            // Its assumed that the directionality of the incoming Wkt is correct
+                            // Further checking could be added to enforce the direction of the
+                            // exterior (first) polygon ring and the subsequent holes
+                            rings.push(exteriorOrHole.map(function (k) {
                                 return [k.x, k.y];
-                            });
-                        });
-
-                        holey = (rings.length > 1);
-
-                        return rings;
+                            }));
+                        })
                     });
 
-                    if (!holey && rings[0].length > 1) { // Easy, if there are no inner rings (holes)
-                        // But we add the second condition to check that we're not too deeply nested
-                        return rings;
-                    }
-
-                    newRings = [];
-                    for (i = 0; i < rings.length; i += 1) {
-                        if (rings[i].length > 1) {
-                            for (j = 0; j < rings[i].length; j += 1) {
-                                newRings.push(rings[i][j]);
-                            }
-                        } else {
-                            newRings.push(rings[i][0]);
-                        }
-                    }
-
-                    return newRings;
-
+                    return rings;
                 }()),
                 spatialReference: config.spatialReference
             });


### PR DESCRIPTION
After encountering a `MULTIPOLYGON` that has a few polygon features, one with a hole. ArcGIS wouldn't draw the `Polygon` created by Wicket. I compared the output of Wicket to that of ArcGIS server. ArcGIS server appears to be flattening the ring hierarchy, and indeed Wicket's deconstruction to WKT seems to expect this. However when creating the ArcGIS `Polygon` Wicket did not perform the same flattening. This PR performs the flattening however doesn't make any checks for directionality not sure if its necessary anyway since the WKT standard defines the directionality as well as ordinality of the rings. 

Let me know if I'm off base, but it appears even the arcgis demo page is affected by this issue. 

All the best.