### PR TITLE
Adding entry point to package.json to fix CommonJS require()

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "license": "GPL-3.0",
   "description": "A modest library for moving between Well-Known Text (WKT) and various framework geometries",
   "homepage": "https://github.com/arthur-e/Wicket",
+  "main": "wicket.js",
   "keywords": [
     "wkt",
     "map",


### PR DESCRIPTION
Without a "main" entry in the package.json file, using `require('wicket')` fails with the following error:

`Error: Cannot find module './node_modules/wicket/wicket.js'`