### PR TITLE
waits for google to load, to pass karma tests

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,19 +1,28 @@
-module.exports = function (config) {
-  config.set({
-    basePath: '',
-    port: 9877,
-    colors: true,
-    logLevel: 'INFO',
-    autoWatch: false,
-    browsers: ['PhantomJS'],
-    singleRun: true,
-    frameworks: ['jasmine'],
-    reporters: ['mocha'],
-    files: [
-      'https://maps.googleapis.com/maps/api/js?v=3.exp&libraries=geometry',
-      'wicket.js',
-      'wicket-gmap3.js',
-      'tests/wicket-gmap3-spec.js'
-    ]
-  });
+module.exports = function(config) {
+    config.set({
+        basePath: '',
+        port: 9877,
+        colors: true,
+        logLevel: 'INFO',
+        autoWatch: false,
+        browsers: ['PhantomJS'],
+        phantomjsLauncher: {
+            // Have phantomjs exit if a ResourceError is encountered (useful if karma exits without killing phantom)
+            exitOnResourceError: false,
+            flags: [
+                '--web-security=false',
+                '--load-images=false',
+                '--ignore-ssl-errors=true'
+            ]
+        },
+        singleRun: true,
+        frameworks: ['jasmine'],
+        reporters: ['mocha'],
+        files: [
+            'https://maps.googleapis.com/maps/api/js?v=3.31&libraries=geometry',
+            'wicket.js',
+            'wicket-gmap3.js',
+            'tests/wicket-gmap3-spec.js'
+        ]
+    });
 };

--- a/tests/wicket-gmap3-spec.js
+++ b/tests/wicket-gmap3-spec.js
@@ -1,6 +1,32 @@
-describe('Standard WKT Test Cases: ', function () {
+describe('Standard WKT Test Cases: ', function() {
     var cases, wkt;
     wkt = new Wkt.Wkt();
+
+    function testAsync(done) {
+        if (window.google) {
+            done();
+        }
+        console.log('waiting for google to load');
+        // Wait one second, then check if google has loaded.
+        // If it hasn't, then wait for another second and so forth
+        setTimeout(function() {
+            if (window.google) {
+                done();
+            } else {
+                testAsync(done);
+            }
+        }, 1000);
+    }
+
+    beforeEach(function(done) {
+        // Make an async call, passing the special done callback 
+        // to ensure google maps is loaded.
+        testAsync(done);
+    });
+
+    it("Type of window.google should be 'object' to ensure the library is loaded in the global scope", function() {
+        expect(typeof window.google).toEqual('object');
+    });
 
     cases = {
 
@@ -578,13 +604,13 @@ describe('Standard WKT Test Cases: ', function () {
 
     dataObjects = new google.maps.Data;
 
-    describe('Converting objects into WKT strings: ', function () {
+    describe('Converting objects into WKT strings: ', function() {
 
-        afterEach(function () {
+        afterEach(function() {
             wkt.delimiter = ' ';
         });
 
-        it('should convert a Marker instance into a basic POINT string', function () {
+        it('should convert a Marker instance into a basic POINT string', function() {
             wkt.fromObject(cases.point.obj);
             expect(wkt.type).toBe('point');
             expect(wkt.isCollection()).toBe(false);
@@ -592,7 +618,7 @@ describe('Standard WKT Test Cases: ', function () {
             expect(wkt.write()).toBe(cases.point.str);
         });
 
-        it('should convert a Polyline instance into a basic LINESTRING string', function () {
+        it('should convert a Polyline instance into a basic LINESTRING string', function() {
             wkt.fromObject(cases.linestring.obj);
             expect(wkt.type).toBe('linestring');
             expect(wkt.isCollection()).toBe(false);
@@ -600,7 +626,7 @@ describe('Standard WKT Test Cases: ', function () {
             expect(wkt.write()).toBe(cases.linestring.str);
         });
 
-        it('should convert a Polygon instance into a basic POLYGON string', function () {
+        it('should convert a Polygon instance into a basic POLYGON string', function() {
             wkt.fromObject(cases.polygon.obj);
             expect(wkt.type).toBe('polygon');
             expect(wkt.isCollection()).toBe(true);
@@ -608,7 +634,7 @@ describe('Standard WKT Test Cases: ', function () {
             expect(wkt.write()).toBe(cases.polygon.str);
         });
 
-        it('should convert a Rectangle instance into a POLYGON string', function () {
+        it('should convert a Rectangle instance into a POLYGON string', function() {
             wkt.fromObject(cases.rectangle.obj);
             expect(wkt.type).toBe('polygon');
             expect(wkt.isRectangle).toBe(true);
@@ -617,7 +643,7 @@ describe('Standard WKT Test Cases: ', function () {
             expect(wkt.write()).toBe(cases.rectangle.str);
         });
 
-        it('should convert an Array of Marker instances into a MULTIPOINT string', function () {
+        it('should convert an Array of Marker instances into a MULTIPOINT string', function() {
             wkt.fromObject(cases.multipoint.obj);
             expect(wkt.type).toBe('multipoint');
             expect(wkt.isCollection()).toBe(true);
@@ -625,7 +651,7 @@ describe('Standard WKT Test Cases: ', function () {
             expect(wkt.write()).toBe(cases.multipoint.str);
         });
 
-        it('should convert an Array of Polyline instances into a MULTILINESTRING string', function () {
+        it('should convert an Array of Polyline instances into a MULTILINESTRING string', function() {
             wkt.fromObject(cases.multilinestring.obj);
             expect(wkt.type).toBe('multilinestring');
             expect(wkt.isCollection()).toBe(true);
@@ -633,7 +659,7 @@ describe('Standard WKT Test Cases: ', function () {
             expect(wkt.write()).toBe(cases.multilinestring.str);
         });
 
-        it('should convert an Array of Polygon instances into a MULTIPOLYGON string', function () {
+        it('should convert an Array of Polygon instances into a MULTIPOLYGON string', function() {
             wkt.fromObject(cases.multipolygon.obj);
             expect(wkt.type).toBe('multipolygon');
             expect(wkt.isCollection()).toBe(true);
@@ -641,7 +667,7 @@ describe('Standard WKT Test Cases: ', function () {
             expect(wkt.write()).toBe(cases.multipolygon.str);
         });
 
-        it('should convert a Polygon instance with a hole into a POLYGON string with the same hole', function () {
+        it('should convert a Polygon instance with a hole into a POLYGON string with the same hole', function() {
             wkt.fromObject(cases.polygon2.obj);
             expect(wkt.type).toBe('polygon');
             expect(wkt.isCollection()).toBe(true);
@@ -649,7 +675,7 @@ describe('Standard WKT Test Cases: ', function () {
             expect(wkt.write()).toBe(cases.polygon2.str);
         });
 
-        it('should convert an Array of Polygon instances, some with holes, into a MULTIPOLYGON string with the same hole', function () {
+        it('should convert an Array of Polygon instances, some with holes, into a MULTIPOLYGON string with the same hole', function() {
             wkt.fromObject(cases.multipolygon2.obj);
             expect(wkt.type).toBe('multipolygon');
             expect(wkt.isCollection()).toBe(true);
@@ -658,13 +684,13 @@ describe('Standard WKT Test Cases: ', function () {
         });
     });
 
-    describe('Converting google.maps.Data objects into WKT strings: ', function () {
+    describe('Converting google.maps.Data objects into WKT strings: ', function() {
 
-        afterEach(function () {
+        afterEach(function() {
             wkt.delimiter = ' ';
         });
 
-        it('should convert a google.maps.Data.Point instance into a basic POINT string', function () {
+        it('should convert a google.maps.Data.Point instance into a basic POINT string', function() {
             var dataPoint = dataObjects.addGeoJson({
                 "type": "Feature",
                 geometry: cases.point.json
@@ -676,7 +702,7 @@ describe('Standard WKT Test Cases: ', function () {
             expect(wkt.write()).toBe(cases.point.str);
         });
 
-        it('should convert a google.maps.Data.LineString instance into a basic LINESTRING string', function () {
+        it('should convert a google.maps.Data.LineString instance into a basic LINESTRING string', function() {
             var dataLineString = dataObjects.addGeoJson({
                 "type": "Feature",
                 geometry: cases.linestring.json
@@ -688,7 +714,7 @@ describe('Standard WKT Test Cases: ', function () {
             expect(wkt.write()).toBe(cases.linestring.str);
         });
 
-        it('should convert a google.maps.Data.Polygon instance into a basic POLYGON string', function () {
+        it('should convert a google.maps.Data.Polygon instance into a basic POLYGON string', function() {
             var dataPolygon = dataObjects.addGeoJson({
                 "type": "Feature",
                 geometry: cases.polygon.json
@@ -700,7 +726,7 @@ describe('Standard WKT Test Cases: ', function () {
             expect(wkt.write()).toBe(cases.polygon.str);
         });
 
-        it('should convert a google.maps.Data.Polygon instance with a hole into a POLYGON string with the same hole', function () {
+        it('should convert a google.maps.Data.Polygon instance with a hole into a POLYGON string with the same hole', function() {
             var dataPolygon2 = dataObjects.addGeoJson({
                 "type": "Feature",
                 geometry: cases.polygon2.json
@@ -712,7 +738,7 @@ describe('Standard WKT Test Cases: ', function () {
             expect(wkt.write()).toBe(cases.polygon2.str);
         });
 
-        it('should convert a google.maps.Data.MultiPoint instance  into a MULTIPOINT string', function () {
+        it('should convert a google.maps.Data.MultiPoint instance  into a MULTIPOINT string', function() {
             var dataMultiPoint = dataObjects.addGeoJson({
                 "type": "Feature",
                 geometry: cases.multipoint.json
@@ -724,7 +750,7 @@ describe('Standard WKT Test Cases: ', function () {
             expect(wkt.write()).toBe(cases.multipoint.str);
         });
 
-        it('should convert a google.maps.Data.MultiLineString instance into a MULTILINESTRING string', function () {
+        it('should convert a google.maps.Data.MultiLineString instance into a MULTILINESTRING string', function() {
             var dataMultiLineString = dataObjects.addGeoJson({
                 "type": "Feature",
                 geometry: cases.multilinestring.json
@@ -736,7 +762,7 @@ describe('Standard WKT Test Cases: ', function () {
             expect(wkt.write()).toBe(cases.multilinestring.str);
         });
 
-        it('should convert a google.maps.Data.MultiPolygon instance into a MULTIPOLYGON string', function () {
+        it('should convert a google.maps.Data.MultiPolygon instance into a MULTIPOLYGON string', function() {
             var dataMultiPolygon = dataObjects.addGeoJson({
                 "type": "Feature",
                 geometry: cases.multipolygon.json
@@ -748,7 +774,7 @@ describe('Standard WKT Test Cases: ', function () {
             expect(wkt.write()).toBe(cases.multipolygon.str);
         });
 
-        it('should convert a google.maps.Data.MultiPolygon with holes, into a MULTIPOLYGON string with the same holes', function () {
+        it('should convert a google.maps.Data.MultiPolygon with holes, into a MULTIPOLYGON string with the same holes', function() {
             var dataMultiPolygon2 = dataObjects.addGeoJson({
                 "type": "Feature",
                 geometry: cases.multipolygon2.json
@@ -760,7 +786,7 @@ describe('Standard WKT Test Cases: ', function () {
             expect(wkt.write()).toBe(cases.multipolygon2.str);
         });
 
-        it('should convert a google.maps.Data.GeometryCollection into a GEOMETRYCOLLECTION string', function () {
+        it('should convert a google.maps.Data.GeometryCollection into a GEOMETRYCOLLECTION string', function() {
             var dataGeometryCollection = dataObjects.addGeoJson({
                 "type": "Feature",
                 geometry: cases.geometrycollection.json
@@ -774,14 +800,14 @@ describe('Standard WKT Test Cases: ', function () {
 
     });
 
-    describe('Coverting WKT strings into objects: ', function () {
+    describe('Coverting WKT strings into objects: ', function() {
 
-        afterEach(function () {
+        afterEach(function() {
             wkt.delimiter = ' ';
             wkt.isRectangle = false;
         });
 
-        it('should convert a basic POINT string to a Marker instance', function () {
+        it('should convert a basic POINT string to a Marker instance', function() {
             wkt.read(cases.marker.str);
             expect(wkt.type).toBe('point');
             expect(wkt.isCollection()).toBe(false);
@@ -789,7 +815,7 @@ describe('Standard WKT Test Cases: ', function () {
             expect(wkt.toObject().getPosition().toString()).toEqual(cases.marker.obj.getPosition().toString());
         });
 
-        it('should convert a basic LINESTRING string to a Polyline instance', function () {
+        it('should convert a basic LINESTRING string to a Polyline instance', function() {
             wkt.read(cases.linestring.str);
             expect(wkt.type).toBe('linestring');
             expect(wkt.isCollection()).toBe(false);
@@ -797,19 +823,19 @@ describe('Standard WKT Test Cases: ', function () {
             expect(wkt.toObject().getPath().getArray().toString()).toEqual(cases.linestring.obj.getPath().getArray().toString());
         });
 
-        it('should convert a basic POLYGON string to a Polygon instance', function () {
+        it('should convert a basic POLYGON string to a Polygon instance', function() {
             wkt.read(cases.polygon.str);
             expect(wkt.type).toBe('polygon');
             expect(wkt.isCollection()).toBe(true);
             expect(wkt.components).toEqual(cases.polygon.cmp);
-            expect(wkt.toObject().getPaths().getArray().map(function (ring) {
+            expect(wkt.toObject().getPaths().getArray().map(function(ring) {
                 return ring.getArray();
-            }).toString()).toEqual(cases.polygon.obj.getPaths().getArray().map(function (ring) {
+            }).toString()).toEqual(cases.polygon.obj.getPaths().getArray().map(function(ring) {
                 return ring.getArray();
             }).toString());
         });
 
-        it('should convert a POLYGON string with a hole to a Polygon instance with the same hole', function () {
+        it('should convert a POLYGON string with a hole to a Polygon instance with the same hole', function() {
             wkt.read(cases.polygon2.str);
             expect(wkt.type).toBe('polygon');
 
@@ -817,14 +843,14 @@ describe('Standard WKT Test Cases: ', function () {
 
             expect(wkt.components).toEqual(cases.polygon2.cmp);
 
-            expect(wkt.toObject().getPaths().getArray().map(function (ring) {
+            expect(wkt.toObject().getPaths().getArray().map(function(ring) {
                 return ring.getArray();
-            }).toString()).toEqual(cases.polygon2.obj.getPaths().getArray().map(function (ring) {
+            }).toString()).toEqual(cases.polygon2.obj.getPaths().getArray().map(function(ring) {
                 return ring.getArray();
             }).toString());
         });
 
-        it('should convert a POLYGON string, with isRectangle=true, into a Rectangle instance', function () {
+        it('should convert a POLYGON string, with isRectangle=true, into a Rectangle instance', function() {
             wkt.read(cases.rectangle.str);
             wkt.isRectangle = true;
             expect(wkt.type).toBe('polygon');
@@ -834,7 +860,7 @@ describe('Standard WKT Test Cases: ', function () {
             expect(wkt.toObject().constructor).toEqual(google.maps.Rectangle);
         });
 
-        it('should convert a MULTIPOINT string into an Array of Marker instances', function () {
+        it('should convert a MULTIPOINT string into an Array of Marker instances', function() {
             var m;
 
             wkt.read(cases.multipoint.str);
@@ -848,59 +874,59 @@ describe('Standard WKT Test Cases: ', function () {
             }
         });
 
-        it('should convert a MULTILINESTRING string into an Array of Polyline instances', function () {
+        it('should convert a MULTILINESTRING string into an Array of Polyline instances', function() {
             wkt.read(cases.multilinestring.str);
             expect(wkt.type).toBe('multilinestring');
             expect(wkt.isCollection()).toBe(true);
             expect(wkt.components).toEqual(cases.multilinestring.cmp);
             //console.debug({wkt:wkt.toObject(), cases:cases.multilinestring.obj});
-            expect(wkt.toObject().map(function (linestring) {
-                return linestring.getPath().getArray().map(function (point) {
+            expect(wkt.toObject().map(function(linestring) {
+                return linestring.getPath().getArray().map(function(point) {
                     return point.toString();
                 });
-            })).toEqual(cases.multilinestring.obj.map(function (linestring) {
-                return linestring.getPath().getArray().map(function (point) {
+            })).toEqual(cases.multilinestring.obj.map(function(linestring) {
+                return linestring.getPath().getArray().map(function(point) {
                     return point.toString();
                 });
             }));
         });
 
-        it('should convert a MULTIPOLYGON string into an Array of Polygon instances', function () {
+        it('should convert a MULTIPOLYGON string into an Array of Polygon instances', function() {
             wkt.read(cases.multipolygon.str);
             expect(wkt.type).toBe('multipolygon');
             expect(wkt.isCollection()).toBe(true);
             expect(wkt.components).toEqual(cases.multipolygon.cmp);
 
-            expect(wkt.toObject().map(function (ring) {
-                return ring.getPath().getArray().map(function (point) {
+            expect(wkt.toObject().map(function(ring) {
+                return ring.getPath().getArray().map(function(point) {
                     return point.toString();
                 });
-            })).toEqual(cases.multipolygon.obj.map(function (ring) {
-                return ring.getPath().getArray().map(function (point) {
+            })).toEqual(cases.multipolygon.obj.map(function(ring) {
+                return ring.getPath().getArray().map(function(point) {
                     return point.toString();
                 });
             }));
 
         });
 
-        it('should convert a MULTIPOLYGON string with holes into an Array of Polygon instances with the same holes', function () {
+        it('should convert a MULTIPOLYGON string with holes into an Array of Polygon instances with the same holes', function() {
             wkt.read(cases.multipolygon2.str);
             expect(wkt.type).toBe('multipolygon');
             expect(wkt.isCollection()).toBe(true);
             expect(wkt.components).toEqual(cases.multipolygon2.cmp);
 
-            expect(wkt.toObject().map(function (ring) {
-                return ring.getPath().getArray().map(function (point) {
+            expect(wkt.toObject().map(function(ring) {
+                return ring.getPath().getArray().map(function(point) {
                     return point.toString();
                 });
-            })).toEqual(cases.multipolygon2.obj.map(function (ring) {
-                return ring.getPath().getArray().map(function (point) {
+            })).toEqual(cases.multipolygon2.obj.map(function(ring) {
+                return ring.getPath().getArray().map(function(point) {
                     return point.toString();
                 });
             }));
         });
 
-        it('should convert a PostGIS 2DBOX string into a Rectangle instance', function () {
+        it('should convert a PostGIS 2DBOX string into a Rectangle instance', function() {
             wkt.read(cases.box.str);
             expect(wkt.type).toBe('box');
             expect(wkt.isCollection()).toBe(false);
@@ -910,14 +936,14 @@ describe('Standard WKT Test Cases: ', function () {
 
     });
 
-    describe('Coverting GeoJSON Objects into google.maps Objects: ', function () {
+    describe('Coverting GeoJSON Objects into google.maps Objects: ', function() {
 
-        afterEach(function () {
+        afterEach(function() {
             wkt.delimiter = ' ';
             wkt.isRectangle = false;
         });
 
-        it('should convert a basic GeoJSON POINT string to a Marker instance', function () {
+        it('should convert a basic GeoJSON POINT string to a Marker instance', function() {
             wkt.fromJson(cases.marker.json);
             expect(wkt.type).toBe('point');
             expect(wkt.isCollection()).toBe(false);
@@ -925,7 +951,7 @@ describe('Standard WKT Test Cases: ', function () {
             expect(wkt.toObject().getPosition().toString()).toEqual(cases.marker.obj.getPosition().toString());
         });
 
-        it('should convert a basic GeoJSON LINESTRING string to a Polyline instance', function () {
+        it('should convert a basic GeoJSON LINESTRING string to a Polyline instance', function() {
             wkt.fromJson(cases.linestring.json);
             expect(wkt.type).toBe('linestring');
             expect(wkt.isCollection()).toBe(false);
@@ -933,20 +959,20 @@ describe('Standard WKT Test Cases: ', function () {
             expect(wkt.toObject().getPath().getArray().toString()).toEqual(cases.linestring.obj.getPath().getArray().toString());
         });
 
-        it('should convert a basic GeoJSON POLYGON string to a Polygon instance', function () {
+        it('should convert a basic GeoJSON POLYGON string to a Polygon instance', function() {
             wkt.fromJson(cases.polygon.json);
             expect(wkt.type).toBe('polygon');
             expect(wkt.isCollection()).toBe(true);
             expect(wkt.components).toEqual(cases.polygon.cmp);
 
-            expect(wkt.toObject().getPaths().getArray().map(function (ring) {
+            expect(wkt.toObject().getPaths().getArray().map(function(ring) {
                 return ring.getArray();
-            }).toString()).toEqual(cases.polygon.obj.getPaths().getArray().map(function (ring) {
+            }).toString()).toEqual(cases.polygon.obj.getPaths().getArray().map(function(ring) {
                 return ring.getArray();
             }).toString());
         });
 
-        it('should convert a GeoJSON POLYGON string with a hole to a Polygon instance with the same hole', function () {
+        it('should convert a GeoJSON POLYGON string with a hole to a Polygon instance with the same hole', function() {
             wkt.fromJson(cases.polygon2.json);
             expect(wkt.type).toBe('polygon');
 
@@ -954,14 +980,14 @@ describe('Standard WKT Test Cases: ', function () {
 
             expect(wkt.components).toEqual(cases.polygon2.cmp);
 
-            expect(wkt.toObject().getPaths().getArray().map(function (ring) {
+            expect(wkt.toObject().getPaths().getArray().map(function(ring) {
                 return ring.getArray();
-            }).toString()).toEqual(cases.polygon2.obj.getPaths().getArray().map(function (ring) {
+            }).toString()).toEqual(cases.polygon2.obj.getPaths().getArray().map(function(ring) {
                 return ring.getArray();
             }).toString());
         });
 
-        it('should convert a GeoJSON MULTIPOINT string into an Array of Marker instances', function () {
+        it('should convert a GeoJSON MULTIPOINT string into an Array of Marker instances', function() {
             var m;
 
             wkt.fromJson(cases.multipoint.json);
@@ -975,53 +1001,53 @@ describe('Standard WKT Test Cases: ', function () {
             }
         });
 
-        it('should convert a GeoJSON MULTILINESTRING string into an Array of Polyline instances', function () {
+        it('should convert a GeoJSON MULTILINESTRING string into an Array of Polyline instances', function() {
             wkt.fromJson(cases.multilinestring.json);
             expect(wkt.type).toBe('multilinestring');
             expect(wkt.isCollection()).toBe(true);
             expect(wkt.components).toEqual(cases.multilinestring.cmp);
             //console.debug({wkt:wkt.toObject(), cases:cases.multilinestring.obj});
-            expect(wkt.toObject().map(function (linestring) {
-                return linestring.getPath().getArray().map(function (point) {
+            expect(wkt.toObject().map(function(linestring) {
+                return linestring.getPath().getArray().map(function(point) {
                     return point.toString();
                 });
-            })).toEqual(cases.multilinestring.obj.map(function (linestring) {
-                return linestring.getPath().getArray().map(function (point) {
+            })).toEqual(cases.multilinestring.obj.map(function(linestring) {
+                return linestring.getPath().getArray().map(function(point) {
                     return point.toString();
                 });
             }));
         });
 
-        it('should convert a GeoJSON MULTIPOLYGON string into an Array of Polygon instances', function () {
+        it('should convert a GeoJSON MULTIPOLYGON string into an Array of Polygon instances', function() {
             wkt.fromJson(cases.multipolygon.json);
             expect(wkt.type).toBe('multipolygon');
             expect(wkt.isCollection()).toBe(true);
             expect(wkt.components).toEqual(cases.multipolygon.cmp);
 
-            expect(wkt.toObject().map(function (ring) {
-                return ring.getPath().getArray().map(function (point) {
+            expect(wkt.toObject().map(function(ring) {
+                return ring.getPath().getArray().map(function(point) {
                     return point.toString();
                 });
-            })).toEqual(cases.multipolygon.obj.map(function (ring) {
-                return ring.getPath().getArray().map(function (point) {
+            })).toEqual(cases.multipolygon.obj.map(function(ring) {
+                return ring.getPath().getArray().map(function(point) {
                     return point.toString();
                 });
             }));
 
         });
 
-        it('should convert a GeoJSON MULTIPOLYGON string with holes into an Array of Polygon instances with the same holes', function () {
+        it('should convert a GeoJSON MULTIPOLYGON string with holes into an Array of Polygon instances with the same holes', function() {
             wkt.fromJson(cases.multipolygon2.json);
             expect(wkt.type).toBe('multipolygon');
             expect(wkt.isCollection()).toBe(true);
             expect(wkt.components).toEqual(cases.multipolygon2.cmp);
 
-            expect(wkt.toObject().map(function (ring) {
-                return ring.getPath().getArray().map(function (point) {
+            expect(wkt.toObject().map(function(ring) {
+                return ring.getPath().getArray().map(function(point) {
                     return point.toString();
                 });
-            })).toEqual(cases.multipolygon2.obj.map(function (ring) {
-                return ring.getPath().getArray().map(function (point) {
+            })).toEqual(cases.multipolygon2.obj.map(function(ring) {
+                return ring.getPath().getArray().map(function(point) {
                     return point.toString();
                 });
             }));

--- a/tests/wicket-gmap3-spec.js
+++ b/tests/wicket-gmap3-spec.js
@@ -6,7 +6,7 @@ describe('Standard WKT Test Cases: ', function() {
         if (window.google) {
             done();
         }
-        console.log('waiting for google to load');
+
         // Wait one second, then check if google has loaded.
         // If it hasn't, then wait for another second and so forth
         setTimeout(function() {
@@ -25,6 +25,7 @@ describe('Standard WKT Test Cases: ', function() {
     });
 
     it("Type of window.google should be 'object' to ensure the library is loaded in the global scope", function() {
+        console.log('waiting for google to load');
         expect(typeof window.google).toEqual('object');
     });
 

--- a/tests/wicket-gmap3.html
+++ b/tests/wicket-gmap3.html
@@ -1,30 +1,26 @@
 <!DOCTYPE HTML>
 <html>
+
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <title>Jasmine Spec Runner v2.0.0</title>
-
     <link rel="shortcut icon" type="image/png" href="../node_modules/jasmine-core/images/jasmine_favicon.png">
     <link rel="stylesheet" type="text/css" href="../node_modules/jasmine-core/lib/jasmine-core/jasmine.css">
-
     <!-- Get Jasmine: https://github.com/pivotal/jasmine -->
     <script type="text/javascript" src="../node_modules/jasmine-core/lib/jasmine-core/jasmine.js"></script>
     <script type="text/javascript" src="../node_modules/jasmine-core/lib/jasmine-core/jasmine-html.js"></script>
     <script type="text/javascript" src="../node_modules/jasmine-core/lib/jasmine-core/boot.js"></script>
-
-    <script src="http://maps.googleapis.com/maps/api/js?libraries=geometry" type="text/javascript"></script>
-
+    <script src="http://maps.googleapis.com/maps/api/js?v=3.31&libraries=geometry" type="text/javascript"></script>
     <!-- include source files here... -->
     <script type="text/javascript" src="../wicket.js"></script>
     <script type="text/javascript" src="../wicket-gmap3.js"></script>
     <!--<script type="text/javascript" src="/static/wicket/wicket-leaflet.src.js"></script>-->
     <!--<script type="text/javascript" src="/static/wicket/wicket-arcgis.src.js"></script>-->
-
     <!-- include spec files here... -->
     <script type="text/javascript" src="wicket-gmap3-spec.js"></script>
-
 </head>
 
 <body>
 </body>
+
 </html>


### PR DESCRIPTION
This fixes the error reported in issue https://github.com/arthur-e/Wicket/issues/123

Currently, PhantomJS isn't able to load `https` resources unless you pass the flag `--ignore-ssl-errors=true`. Therefore, the config in `karma.conf.js` has a new section to configure PhantomJS:

```js
        phantomjsLauncher: {
            exitOnResourceError: false,
            flags: [
                '--web-security=false',
                '--load-images=false',
                '--ignore-ssl-errors=true'
            ]
        },
```

(The other approach would be to request google maps API using `http` instead of `https`, but we don't know if they would support that protocol in the long term).

I also pinned `google.maps.api` version to `3.31` (current stable) because `3.32` (3.exp) adds a new renderer and base map that will be subject to several changes soon, so why take the risk now. 

The test file `wicket-gmap3-spec.js` has now a `testAsync` function:

```js
function testAsync(done) {
        if (window.google) {
            done();
        }
        console.log('waiting for google to load');
        // Wait one second, then check if google has loaded.
        // If it hasn't, then wait for another second and so forth
        setTimeout(function() {
            if (window.google) {
                done();
            } else {
                testAsync(done);
            }
        }, 1000);
    }
```

This condition is checked declaring `beforeEach`

```js
    beforeEach(function(done) {
        // Make an async call, passing the special done callback 
        // to ensure google maps is loaded.
        testAsync(done);
    });
```

And we add an assertion to ensure `google.maps` is loaded:

```js
    it("Type of window.google should be 'object' to ensure the library is loaded in the global scope", function() {
        expect(typeof window.google).toEqual('object');
    });
```

