### PR TITLE
Latest leaflet compatibility

### DIFF
--- a/doc/leaflet.html
+++ b/doc/leaflet.html
@@ -3,16 +3,16 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <!-- Conditional commenting for non-IE browsers -->
         <!--[if !IE]><!-->
-            <link rel="stylesheet" type="text/css" href="/static/wicket/doc/index.css" />
+            <link rel="stylesheet" type="text/css" href="/doc/index.css" />
         <!--<![endif]-->
     <!-- Conditional commenting for IE 6.x -->
         <!--[if IE]>
             <link rel="stylesheet" type="text/css" href="/static/wicket/doc/index.ie.css" />
         <![endif]-->
-    <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.css" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.3.1/leaflet.css" />
 </head>
 <title>Wicket - Lightweight Javascript for WKT [Leaflet Sandbox]</title>
-<script src="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.3.1/leaflet.js"></script>
 <!--See https://github.com/seelmann/leaflet-providers for below-->
 <script src="../node_modules/leaflet-providers/leaflet-providers.js"></script>
 <script src="../wicket.js" type="text/javascript"></script>

--- a/doc/leaflet.html
+++ b/doc/leaflet.html
@@ -3,7 +3,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <!-- Conditional commenting for non-IE browsers -->
         <!--[if !IE]><!-->
-            <link rel="stylesheet" type="text/css" href="/doc/index.css" />
+            <link rel="stylesheet" type="text/css" href="/static/wicket/doc/index.css" />
         <!--<![endif]-->
     <!-- Conditional commenting for IE 6.x -->
         <!--[if IE]>

--- a/wicket-leaflet.js
+++ b/wicket-leaflet.js
@@ -112,7 +112,7 @@
          */
         linestring: function (config, component) {
             var coords = component || this.components,
-                latlngs = this.coordsToLatLngs(coords);
+                latlngs = this.coordsToLatLngs(coords, 0, this.coordsToLatLng);
 
             return L.polyline(latlngs, config);
         },
@@ -124,7 +124,7 @@
          */
         multilinestring: function (config) {
             var coords = this.components,
-                latlngs = this.coordsToLatLngs(coords, 1);
+                latlngs = this.coordsToLatLngs(coords, 1, this.coordsToLatLng);
 
             return L.multiPolyline(latlngs, config);
         },
@@ -137,7 +137,7 @@
         polygon: function (config) {
             // Truncate the coordinates to remove the closing coordinate
             var coords = this.trunc(this.components),
-                latlngs = this.coordsToLatLngs(coords, 1);
+                latlngs = this.coordsToLatLngs(coords, 1, this.coordsToLatLng);
             return L.polygon(latlngs, config);
         },
 
@@ -149,7 +149,7 @@
         multipolygon: function (config) {
             // Truncate the coordinates to remove the closing coordinate
             var coords = this.trunc(this.components),
-                latlngs = this.coordsToLatLngs(coords, 2);
+                latlngs = this.coordsToLatLngs(coords, 2, this.coordsToLatLng);
 
             return L.multiPolygon(latlngs, config);
         },

--- a/wicket-leaflet.js
+++ b/wicket-leaflet.js
@@ -27,7 +27,7 @@
 (function ( root, factory ) {
     if ( typeof exports === 'object' ) {
         // CommonJS
-        factory( require('./wicket') );
+        module.exports = factory( require('./wicket') );
     } else if ( typeof define === 'function' && define.amd ) {
         // AMD. Register as an anonymous module.
         define( ['wicket'], factory);
@@ -126,7 +126,12 @@
             var coords = this.components,
                 latlngs = this.coordsToLatLngs(coords, 1, this.coordsToLatLng);
 
-            return L.multiPolyline(latlngs, config);
+            if (L.multiPolyline) {
+                return L.multiPolyline(latlngs, config);
+            }
+            else {
+                return L.polyline(latlngs, config);
+            }
         },
 
         /**
@@ -151,7 +156,12 @@
             var coords = this.trunc(this.components),
                 latlngs = this.coordsToLatLngs(coords, 2, this.coordsToLatLng);
 
-            return L.multiPolygon(latlngs, config);
+            if (L.multiPolygon) {
+                return L.multiPolygon(latlngs, config);
+            }
+            else {
+                return L.polygon(latlngs, config);
+            }
         },
 
         /**
@@ -169,7 +179,6 @@
             }
 
             return L.featureGroup(layers, config);
-
         }
     };
 


### PR DESCRIPTION
`leaflet` changed the API for `coordsToLatLngs` in v1.x. 

removed line: https://github.com/Leaflet/Leaflet/commit/703ae02aa8cbd0b87be5b01e77754b83ad732267#diff-cd7cdd28f50ed77d5b608a3b1d53e45bL223

added line: https://github.com/Leaflet/Leaflet/commit/703ae02aa8cbd0b87be5b01e77754b83ad732267#diff-cd7cdd28f50ed77d5b608a3b1d53e45bR235

My changes here just use the new API and reintroduce https://github.com/arthur-e/Wicket/pull/98