### PR TITLE
Bugfix: Check for circle constructor

### DIFF
--- a/wicket-leaflet.js
+++ b/wicket-leaflet.js
@@ -420,7 +420,7 @@
         }
 
         // L.Circle ////////////////////////////////////////////////////////////////
-        if (obj.constructor === L.Rectangle || obj.constructor === L.rectangle) {
+        if (obj.constructor === L.Circle || obj.constructor === L.circle) {
             console.log('Deconstruction of L.Circle objects is not yet supported');
 
         } else {


### PR DESCRIPTION
Pull request to fix issue #130 

```
   // L.Circle ////////////////////////////////////////////////////////////////
        if (obj.constructor === L.Rectangle || obj.constructor === L.rectangle) {
console.log('Deconstruction of L.Circle objects is not yet supported');

```

The test is currently checking for constructor L.Rectangle, but obviously this should be L.Circle/L.circle.
