### PR TITLE
Fix google maps circle to polygon conversion

### DIFF
--- a/wicket-gmap3.js
+++ b/wicket-gmap3.js
@@ -403,7 +403,7 @@
             var rlat = (radius / earthsradius) * r2d;
             var rlng = rlat / Math.cos(point.lat() * d2r);
 
-            for (var n = 0; n <= num_seg; n++) {
+            for (var n = 0; n < num_seg; n++) {
                 var theta = Math.PI * (n / (num_seg / 2));
                 lng = point.lng() + (rlng * Math.cos(theta)); // center a + radius x * cos(theta)
                 lat = point.lat() + (rlat * Math.sin(theta)); // center b + radius y * sin(theta)
@@ -412,6 +412,7 @@
                     y: lat
                 });
             }
+            verts.push(verts[0]);
 
             response = {
                 type: 'polygon',


### PR DESCRIPTION
When converting a large google maps circle (e.g. a circle covering Africa) to a WKT polygon the first and last coordinate of the output are not exactly the same, this causes issues when using it in other libraries. In my case JSTS complains that the linestring is not closed. This is an example of such a converted circle: `POLYGON((71.69991307132003 0.9262704706813841,...,71.69991307132003 0.9262704706813717))`.
To ensure the calculated polygon is closed the last vertex will no longer be calculated but copied over from the first vertex.