### PR TITLE
Global variable `boundary`

### DIFF
--- a/wicket-leaflet.js
+++ b/wicket-leaflet.js
@@ -203,7 +203,7 @@
      * @return      {Object}    A hash of the 'type' and 'components' thus derived
      */
     Wkt.Wkt.prototype.deconstruct = function (obj) {
-        var attr, coordsFromLatLngs, features, i, verts, rings, tmp;
+        var attr, coordsFromLatLngs, features, i, verts, rings, tmp, boundary;
 
         /**
          * Accepts an Array (arr) of LatLngs from which it extracts each one as a


### PR DESCRIPTION
In `Wkt.Wkt.prototype.deconstruct` the variable `boundary` is not declared. This fix corrects the syntax error, so we can run it in strict mode (now the default with ES6 modules).